### PR TITLE
Fix .desktop file installation from justfile

### DIFF
--- a/justfile
+++ b/justfile
@@ -50,7 +50,7 @@ run *args:
 # Installs files
 install:
     install -Dm0755 {{bin-src}} {{bin-dst}}
-    install -Dm-644 {{desktop-src}} {{desktop-dest}}
+    install -Dm0644 {{desktop-src}} {{desktop-dest}}
 
 # Uninstalls installed files
 uninstall:


### PR DESCRIPTION
The correct installation should be -Dm0644, not -Dm-644